### PR TITLE
🐛 fix extra re-render in accordion wc

### DIFF
--- a/packages/accordion/src/components/accordion/accordion.spec.ts
+++ b/packages/accordion/src/components/accordion/accordion.spec.ts
@@ -17,7 +17,7 @@ describe('ip-accordion', () => {
                             <span part="acc-title" class="accordion-title">Accessibilité</span>
                         </button>
                         </h2>
-                        <div part="acc-content" id="sect-1" class="js-panel" style="display: none;">
+                        <div part="acc-content" id="sect-1" class="js-panel" >
                             <div class="acc-content">
                                 <img class="acc-content__image" src="/assets/images/tab-img-1.png" alt="">
                                 <div class="acc-content__desc-wrapper">
@@ -56,7 +56,7 @@ describe('ip-accordion', () => {
                                 <span part="acc-title" class="accordion-title">Panel 1</span>
                             </button>
                         </h2>
-                        <div part="acc-content" id="panel-1" class="js-panel" style="display: none;">
+                        <div part="acc-content" id="panel-1" class="js-panel" >
                         <slot name="accordion-1"></slot>
                         </div>
                     </div>

--- a/packages/accordion/src/components/accordion/accordion.tsx
+++ b/packages/accordion/src/components/accordion/accordion.tsx
@@ -52,23 +52,23 @@ export class Ipaccordion {
 
   componentWillLoad() {
     this.arrayDataWatcher(this.accordionHeaders);
+    requestAnimationFrame(() => {
+      this.accHeaderButtons = this.el.shadowRoot
+        .querySelector('#ip-accordion')
+        .querySelectorAll('button');
+
+      this.accPanels = this.el.shadowRoot
+        .querySelector('#ip-accordion')
+        .querySelectorAll('.js-panel');
+
+      this.setSlotId();
+
+      this.hidePanels();
+
+      this.openFirstPanel();
+    });
   }
 
-  componentDidLoad() {
-    this.accHeaderButtons = this.el.shadowRoot
-      .querySelector('#ip-accordion')
-      .querySelectorAll('button');
-
-    this.accPanels = this.el.shadowRoot
-      .querySelector('#ip-accordion')
-      .querySelectorAll('.js-panel');
-
-    this.setSlotId();
-
-    this.hidePanels();
-
-    this.openFirstPanel();
-  }
   // keep first panel open or not depending on prop 'isFirstPanelOpen'
   openFirstPanel() {
     if (this.isFirstPanelOpen) {


### PR DESCRIPTION
fix this error =>
 The state/prop "accHeaderButtons" changed during "componentDidLoad()", this triggers extra re-renders, try to setup on "componentWillLoad()" 